### PR TITLE
Ability to pass request content to SpringWebFluxContext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,42 @@
             <version>3.25.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <version>3.6.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>3.2.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Required for WebTestClient-->
+        <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-api</artifactId>
+            <version>2.2.0-M1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Required for WebTestClient-->
+        <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-client-api</artifactId>
+            <version>2.2.0-M1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/pac4j/springframework/context/SpringWebfluxWebContext.java
+++ b/src/main/java/org/pac4j/springframework/context/SpringWebfluxWebContext.java
@@ -20,6 +20,7 @@ import java.util.*;
  * @since 1.0.0
  */
 public class SpringWebfluxWebContext implements WebContext {
+    public static final String SAML_BODY_ATTRIBUTE = "PAC4J_REQUEST_CONTENT";
 
     private final ServerWebExchange exchange;
 
@@ -159,5 +160,16 @@ public class SpringWebfluxWebContext implements WebContext {
     @Override
     public String getPath() {
         return request.getPath().value();
+    }
+
+    /**
+     * Authentication mechanisms like SAML requires the request content
+     * to extract relevant authentication parameters.
+     * @return Callback request content.
+     */
+    @Override
+    public  String getRequestContent() {
+        final Map<String, Object> attributes = exchange.getAttributes();
+        return (String) attributes.get(SAML_BODY_ATTRIBUTE);
     }
 }

--- a/src/test/java/org/pac4j/springframework/web/CallbackControllerTest.java
+++ b/src/test/java/org/pac4j/springframework/web/CallbackControllerTest.java
@@ -1,0 +1,68 @@
+package org.pac4j.springframework.web;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.pac4j.core.config.Config;
+import org.pac4j.springframework.context.SpringWebfluxWebContextFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import reactor.core.publisher.Mono;
+
+@ExtendWith(SpringExtension.class)
+@WebFluxTest(controllers = CallbackController.class)
+@Import(CallbackControllerTest.TestConfig.class)
+public class CallbackControllerTest {
+
+    @Autowired
+    private WebTestClient webClient;
+
+    @Value("${pac4j.callback.path:/callback}")
+    private String callbackPath;
+
+    @Autowired
+    public Config config;
+
+    @Test
+    void testRequestContentIsPassedToWebContext() {
+        LinkedMultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("param1", "XXXX");
+        formData.add("param2", "YYYY");
+
+        Mockito.when(config.getCallbackLogic()).thenReturn((config, s, aBoolean, s1, frameworkParameters) -> {
+            final String requestContext = SpringWebfluxWebContextFactory.INSTANCE.newContext(frameworkParameters).getRequestContent();
+            Assertions.assertEquals(requestContext, "param1=XXXX&param2=YYYY");
+            return Mono.empty();
+        });
+
+        webClient.post()
+                .uri(callbackPath)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData(formData))
+                .exchange()
+                .expectStatus()
+                .isOk();
+    }
+
+    @SpringBootConfiguration
+    public static class TestConfig {
+        @MockBean
+        public Config config;
+        @Bean
+        public CallbackController callbackController() {
+            return new CallbackController();
+        }
+    }
+}
+


### PR DESCRIPTION
SpringWebfluxWebContext does not override getRequestContent() and hence uses the default implementation which throws an exception:

default String getRequestContent() {
        throw new TechnicalException("Operation not supported");
    }

Request Content is required for authentication providers like Saml to extract the relevant authentication parameters values.